### PR TITLE
fix redis probe config

### DIFF
--- a/chart/todo/values.yaml
+++ b/chart/todo/values.yaml
@@ -17,5 +17,17 @@ redis:
   master:
     livenessProbe:
       enabled: true
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 5
+      successThreshold: 1
+      failureThreshold: 5
+
+    # Redis slave Readiness Probe
     readinessProbe:
       enabled: true
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 10
+      successThreshold: 1
+      failureThreshold: 5


### PR DESCRIPTION
The redis chart expects all these values to be set, otherwise they will
be set to an empty string and fail validation. This is a bug in the
upstream chart, but this will fix this one for now.