### PR TITLE
chart: use the readwrite endpoints for all functions when there are no slaves

### DIFF
--- a/chart/todo/Chart.yaml
+++ b/chart/todo/Chart.yaml
@@ -1,5 +1,5 @@
 name: todo
-version: 0.1.4
+version: 0.1.5
 appVersion: 0.1.0
 description: Todo is a simple todo application that uses ReactJS for the frontend and kubeless functions for the backend api.
 icon: https://www.shareicon.net/download/2016/11/16/854159_pencil_512x512.png

--- a/chart/todo/templates/_helpers.tpl
+++ b/chart/todo/templates/_helpers.tpl
@@ -33,6 +33,15 @@ Create chart name and version as used by the chart label.
 
 
 {{/*
+Return the proper Node image name
+*/}}
+{{- define "todo.image" -}}
+{{- $registryName :=  default "docker.io" .Values.image.registry -}}
+{{- $tag := default "latest" .Values.image.tag -}}
+{{- printf "%s/%s:%s" $registryName .Values.image.repository $tag -}}
+{{- end -}}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
@@ -40,11 +49,21 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "%s-%s" .Release.Name "redis" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+
 {{/*
-Return the proper Node image name
+Return the redis readwrite hostname
 */}}
-{{- define "todo.image" -}}
-{{- $registryName :=  default "docker.io" .Values.image.registry -}}
-{{- $tag := default "latest" .Values.image.tag -}}
-{{- printf "%s/%s:%s" $registryName .Values.image.repository $tag -}}
+{{- define "todo.redis.host.readwrite" -}}
+{{- printf "%s-%s-%s" .Release.Name "redis" "master" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Return the redis readonly hostname
+*/}}
+{{- define "todo.redis.host.readonly" -}}
+{{- if and .Values.redis.cluster.enabled (gt (int .Values.redis.cluster.slaveCount) 0) -}}
+{{- printf "%s-%s-%s" .Release.Name "redis" "slave" | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s-%s" .Release.Name "redis" "master" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}

--- a/chart/todo/templates/backend-functions.yaml
+++ b/chart/todo/templates/backend-functions.yaml
@@ -17,7 +17,7 @@ spec:
           - name: create
             env:
             - name: REDIS_HOST
-              value: {{ template "todo.redis.fullname" . }}-master
+              value: {{ template "todo.redis.host.readwrite" . }}
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -61,7 +61,7 @@ spec:
           - name: update
             env:
             - name: REDIS_HOST
-              value: {{ template "todo.redis.fullname" . }}-master
+              value: {{ template "todo.redis.host.readwrite" . }}
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -105,7 +105,7 @@ spec:
           - name: delete
             env:
             - name: REDIS_HOST
-              value: {{ template "todo.redis.fullname" . }}-master
+              value: {{ template "todo.redis.host.readwrite" . }}
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -149,7 +149,7 @@ spec:
           - name: read-one
             env:
             - name: REDIS_HOST
-              value: {{ template "todo.redis.fullname" . }}-slave
+              value: {{ template "todo.redis.host.readonly" . }}
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -193,7 +193,7 @@ spec:
           - name: read-all
             env:
             - name: REDIS_HOST
-              value: {{ template "todo.redis.fullname" . }}-slave
+              value: {{ template "todo.redis.host.readonly" . }}
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
If redis cluster setup is disabled, the application should use the redis master hostname for the readonly endpoints (read-one/read-all).