### PR TITLE
Upgrade webpack-dev-server because of CVE-2018-14732

### DIFF
--- a/frontend/react-redux/package.json
+++ b/frontend/react-redux/package.json
@@ -25,7 +25,7 @@
     "file-loader": "^0.9.0",
     "react-hot-loader": "^3.0.0-beta.3",
     "webpack": "^1.13.2",
-    "webpack-dev-server": "^1.15.1"
+    "webpack-dev-server": ">=3.1.11"
   },
   "dependencies": {
     "babel-plugin-transform-class-properties": "^6.11.5",


### PR DESCRIPTION
This PR upgrade `webpack-dev-server` to version 3.1.11 or later because of a security issue:

[**CVE-2018-14732**](https://nvd.nist.gov/vuln/detail/CVE-2018-14732)
**Vulnerable versions**: < 3.1.11
**Patched version**: 3.1.11
An issue was discovered in lib/Server.js in webpack-dev-server before 3.1.11. Attackers are able to steal developer's code because the origin of requests is not checked by the WebSocket server, which is used for HMR (Hot Module Replacement). Anyone can receive the HMR message sent by the WebSocket server via a ws://127.0.0.1:8080/ connection from any origin.